### PR TITLE
Add interface documentation comments

### DIFF
--- a/pkg/calendar/service.go
+++ b/pkg/calendar/service.go
@@ -4,6 +4,7 @@ import "context"
 
 //go:generate mockgen -source service.go -package mock -destination mock/mock.go
 
+// Service handles interactions with a calendar provider.
 type Service interface {
 	CreateEvent(ctx context.Context, params CreateEventParams) (string, error)
 }

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -15,12 +15,14 @@ type ContextWindowManager interface {
 	SaveHistory(ctx context.Context, id string, history []llms.MessageContent) error
 }
 
+// Tool defines a callable function that can be registered with the registry.
 type Tool interface {
 	Definition() llms.Tool
 	SystemPrompt() string
 	Execute(ctx context.Context, toolCall llms.ToolCall) (*llms.MessageContent, error)
 }
 
+// Registry provides access to registered tools and executes them when needed.
 type Registry interface {
 	Register(tool Tool)
 	GetTools() []llms.Tool


### PR DESCRIPTION
## Summary
- add GoDoc for `Service` interface in calendar package
- document `Tool` and `Registry` interfaces in tools package

## Testing
- `go test ./...` *(fails: fetching modules is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6855c50c77288321bc4481ae45b6c671